### PR TITLE
bugfix :: duckdb azure cannot soft-delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,14 @@
 | <a name="input_db_password"></a> [db\_password](#input\_db\_password) | Database password. | `string` | `null` | no |
 | <a name="input_dev_token_private_key"></a> [dev\_token\_private\_key](#input\_dev\_token\_private\_key) | Private key used to sign dev tokens. | `string` | n/a | yes |
 | <a name="input_domain"></a> [domain](#input\_domain) | App domain name. | `string` | n/a | yes |
-| <a name="input_enable_blob_soft_delete"></a> [enable\_blob\_soft\_delete](#input\_enable\_blob\_soft\_delete) | Whether to enable soft delete for blobs in the main storage account. | `bool` | `true` | no |
+| <a name="input_enable_blob_soft_delete"></a> [enable\_blob\_soft\_delete](#input\_enable\_blob\_soft\_delete) | Whether to enable soft delete for blobs in the main storage account. Must be false when using the ADLS Gen2 (abfs://) endpoint, which does not support soft delete. | `bool` | `false` | no |
 | <a name="input_flower_basic_auth_password"></a> [flower\_basic\_auth\_password](#input\_flower\_basic\_auth\_password) | Flower basic auth password for UI access. | `string` | `null` | no |
 | <a name="input_flower_basic_auth_username"></a> [flower\_basic\_auth\_username](#input\_flower\_basic\_auth\_username) | Flower basic auth username for UI access. | `string` | `null` | no |
 | <a name="input_flower_enabled"></a> [flower\_enabled](#input\_flower\_enabled) | Whether to enable Flower monitoring for Celery queues. | `bool` | `false` | no |
 | <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Helm chart version. | `string` | `"0.30.0"` | no |
 | <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name. | `string` | `"dbnl"` | no |
 | <a name="input_helm_release_namespace"></a> [helm\_release\_namespace](#input\_helm\_release\_namespace) | Helm release namespace. | `string` | `"default"` | no |
+| <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Container image tag override. Defaults to helm\_chart\_version when null. | `string` | `null` | no |
 | <a name="input_instance_size"></a> [instance\_size](#input\_instance\_size) | App instance size | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The Azure region where all resources will be created. | `string` | `"Central US"` | no |
 | <a name="input_oidc_audience"></a> [oidc\_audience](#input\_oidc\_audience) | OIDC audience. | `string` | `null` | no |
@@ -81,6 +82,7 @@
 | <a name="output_cluster_client_certificate"></a> [cluster\_client\_certificate](#output\_cluster\_client\_certificate) | The AKS cluster client certificate. |
 | <a name="output_cluster_client_key"></a> [cluster\_client\_key](#output\_cluster\_client\_key) | The AKS cluster client key. |
 | <a name="output_cluster_host"></a> [cluster\_host](#output\_cluster\_host) | The AKS cluster host. |
+| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | The AKS cluster name. |
 | <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | The name of the Azure Resource Group. |
 | <a name="output_subnets"></a> [subnets](#output\_subnets) | A map of the created subnets. |
 | <a name="output_vnet_id"></a> [vnet\_id](#output\_vnet\_id) | The ID of the created Azure Virtual Network. |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -33,5 +33,5 @@ module "dbnl" {
   domain                = var.domain
   instance_size         = "small"
   public_facing         = true
-  helm_chart_version    = "0.30.0"
+  helm_chart_version    = "0.31.1"
 }

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -2,3 +2,8 @@ output "resource_group_name" {
   description = "The name of the Azure Resource Group."
   value       = module.dbnl.resource_group_name
 }
+
+output "cluster_name" {
+  description = "The AKS cluster name."
+  value       = module.dbnl.cluster_name
+}

--- a/main.tf
+++ b/main.tf
@@ -137,6 +137,7 @@ module "app" {
   admin_password = var.admin_password
 
   helm_chart_version     = var.helm_chart_version
+  image_tag              = var.image_tag
   helm_release_name      = var.helm_release_name
   helm_release_namespace = var.helm_release_namespace
 

--- a/modules/app/README.md
+++ b/modules/app/README.md
@@ -43,6 +43,7 @@ No modules.
 | <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Helm chart version. | `string` | n/a | yes |
 | <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name. | `string` | `"dbnl"` | no |
 | <a name="input_helm_release_namespace"></a> [helm\_release\_namespace](#input\_helm\_release\_namespace) | Helm release namespace. | `string` | `"default"` | no |
+| <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Container image tag override. Defaults to helm\_chart\_version when null. | `string` | `null` | no |
 | <a name="input_oidc_audience"></a> [oidc\_audience](#input\_oidc\_audience) | OIDC audience. | `string` | `null` | no |
 | <a name="input_oidc_client_id"></a> [oidc\_client\_id](#input\_oidc\_client\_id) | OIDC client id. | `string` | `null` | no |
 | <a name="input_oidc_issuer"></a> [oidc\_issuer](#input\_oidc\_issuer) | OIDC issuer. | `string` | `null` | no |

--- a/modules/app/main.tf
+++ b/modules/app/main.tf
@@ -4,6 +4,8 @@ locals {
 
   flower_basic_auth_enabled = nonsensitive(var.flower_basic_auth_username != null && var.flower_basic_auth_password != null)
 
+  image_tag = coalesce(var.image_tag, var.helm_chart_version)
+
   lb_annotations = {
     "kubernetes.io/ingress.class" : "azure/application-gateway"
     "cert-manager.io/cluster-issuer" : var.cert_manager_cluster_issuer
@@ -55,7 +57,7 @@ locals {
       }
       image = {
         repository = "${var.registry_server}/images/api-srv"
-        tag        = var.helm_chart_version
+        tag        = local.image_tag
       }
     }
     auth = {
@@ -119,7 +121,7 @@ locals {
       }
       image = {
         repository = "${var.registry_server}/images/migration-job"
-        tag        = var.helm_chart_version
+        tag        = local.image_tag
       }
     }
     scheduler = {
@@ -135,7 +137,7 @@ locals {
       }
       image = {
         repository = "${var.registry_server}/images/scheduler-srv"
-        tag        = var.helm_chart_version
+        tag        = local.image_tag
       }
     }
     ui = {
@@ -150,7 +152,7 @@ locals {
       }
       image = {
         repository = "${var.registry_server}/images/ui-srv"
-        tag        = var.helm_chart_version
+        tag        = local.image_tag
       }
     }
     worker = {
@@ -168,7 +170,7 @@ locals {
       }
       image = {
         repository = "${var.registry_server}/images/worker-srv"
-        tag        = var.helm_chart_version
+        tag        = local.image_tag
       }
     }
     flower = var.flower_enabled ? {
@@ -188,7 +190,7 @@ locals {
       }
       image = {
         repository = "${var.registry_server}/images/flower-srv"
-        tag        = var.helm_chart_version
+        tag        = local.image_tag
       }
       } : {
       enabled        = false
@@ -200,7 +202,7 @@ locals {
       port = 0
       image = {
         repository = "${var.registry_server}/images/flower-srv"
-        tag        = var.helm_chart_version
+        tag        = local.image_tag
       }
     }
     storage = {

--- a/modules/app/variables.tf
+++ b/modules/app/variables.tf
@@ -68,6 +68,12 @@ variable "helm_chart_version" {
   description = "Helm chart version."
 }
 
+variable "image_tag" {
+  type        = string
+  description = "Container image tag override. Defaults to helm_chart_version when null."
+  default     = null
+}
+
 variable "helm_release_name" {
   type        = string
   description = "Helm release name."

--- a/modules/kubernetes/README.md
+++ b/modules/kubernetes/README.md
@@ -47,5 +47,6 @@ No modules.
 | <a name="output_cluster_client_certificate"></a> [cluster\_client\_certificate](#output\_cluster\_client\_certificate) | Kubernetes cluster client certificate |
 | <a name="output_cluster_client_key"></a> [cluster\_client\_key](#output\_cluster\_client\_key) | Kubernetes cluster client certificate |
 | <a name="output_cluster_host"></a> [cluster\_host](#output\_cluster\_host) | Kubernetes cluster host |
+| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | AKS cluster name |
 | <a name="output_cluster_oidc_issuer_url"></a> [cluster\_oidc\_issuer\_url](#output\_cluster\_oidc\_issuer\_url) | Kubernetes cluster OIDC issuer URL |
 <!-- END_TF_DOCS -->

--- a/modules/kubernetes/outputs.tf
+++ b/modules/kubernetes/outputs.tf
@@ -1,3 +1,8 @@
+output "cluster_name" {
+  description = "AKS cluster name"
+  value       = azurerm_kubernetes_cluster.aks.name
+}
+
 output "cluster_host" {
   description = "Kubernetes cluster host"
   value       = azurerm_kubernetes_cluster.aks.kube_config[0].host

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "subnets" {
   value       = module.network.subnets
 }
 
+output "cluster_name" {
+  description = "The AKS cluster name."
+  value       = module.kubernetes.cluster_name
+}
+
 output "cluster_host" {
   description = "The AKS cluster host."
   value       = module.kubernetes.cluster_host

--- a/variables.tf
+++ b/variables.tf
@@ -47,9 +47,9 @@ variable "private_ip_address" {
 }
 
 variable "enable_blob_soft_delete" {
-  description = "Whether to enable soft delete for blobs in the main storage account."
+  description = "Whether to enable soft delete for blobs in the main storage account. Must be false when using the ADLS Gen2 (abfs://) endpoint, which does not support soft delete."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "blob_soft_delete_retention_days" {

--- a/variables.tf
+++ b/variables.tf
@@ -146,6 +146,12 @@ variable "helm_chart_version" {
   default     = "0.30.0"
 }
 
+variable "image_tag" {
+  type        = string
+  description = "Container image tag override. Defaults to helm_chart_version when null."
+  default     = null
+}
+
 variable "helm_release_name" {
   type        = string
   description = "Helm release name."


### PR DESCRIPTION
### TODO:
- confirm after merging upstream duckdb-related fixes; backport and then bump version here (eg `0.31.2`)

### 📌 Summary
- encountered a permissions issue with soft-delete; related to using abfs:// rather than az:// but we're stuck with that for now, as pyiceberg / duckdb only support abfs.
- some other helper pieces to make debugging and dev-deploy-testing easier

### ❓ Ticket / Justification
Why are you making this change?

### 🧪 Test plan
How did you test it?

### 📝 Notes
Anything else (e.g. rollback plan)?
