### PR TITLE
ENG-3627 :: bump helm v3

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -2,3 +2,9 @@ formatter: "markdown table"
 
 recursive:
   enabled: true
+
+# Root `.terraform.lock.hcl` is gitignored but often exists locally after `terraform
+# init`; without this, terraform-docs resolves exact provider versions from the
+# lockfile while CI (no lockfile) emits constraints — CI pre-commit then fails.
+settings:
+  lockfile: false

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.69.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.8.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 3.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.69.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.8.1 |
 
 ## Modules
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -11,7 +11,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.dbnl.cluster_host
     cluster_ca_certificate = base64decode(module.dbnl.cluster_ca_certificate)
     client_key             = base64decode(module.dbnl.cluster_client_key)

--- a/examples/oidc/main.tf
+++ b/examples/oidc/main.tf
@@ -11,7 +11,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.dbnl.cluster_host
     cluster_ca_certificate = base64decode(module.dbnl.cluster_ca_certificate)
     client_key             = base64decode(module.dbnl.cluster_client_key)

--- a/modules/app/.terraform-docs.yml
+++ b/modules/app/.terraform-docs.yml
@@ -1,0 +1,9 @@
+formatter: "markdown table"
+
+# This module’s `.terraform.lock.hcl` is typically gitignored when present; CI has
+# no lockfile. Nested READMEs are generated per-module; without `lockfile: false`
+# here, terraform-docs can still use a local lockfile for provider version cells
+# while CI emits constraints/`n/a` — pre-commit fails. Kept identical across
+# terraform-{aws,azurerm,google}-dbnl.
+settings:
+  lockfile: false

--- a/modules/app/main.tf
+++ b/modules/app/main.tf
@@ -231,54 +231,22 @@ resource "helm_release" "dbnl" {
 
   values = [yamlencode(local.values)]
 
-  dynamic "set_sensitive" {
-    for_each = local.admin_enabled ? ["admin-enabled"] : []
-    content {
-      name  = "auth.admin.hashedPassword"
-      value = bcrypt(var.admin_password)
-    }
-  }
-
-  set_sensitive {
-    name  = "auth.devToken.privateKey"
-    value = var.dev_token_private_key
-  }
-
-  set_sensitive {
-    name  = "redis.username"
-    value = var.redis_username
-  }
-
-  set_sensitive {
-    name  = "redis.password"
-    value = var.redis_password
-  }
-
-  set_sensitive {
-    name  = "db.username"
-    value = var.db_username
-  }
-
-  set_sensitive {
-    name  = "db.password"
-    value = var.db_password
-  }
-
-  dynamic "set_sensitive" {
-    for_each = local.flower_basic_auth_enabled ? ["flower-basic-auth-password"] : []
-    content {
-      name  = "flower.basicAuth.password"
-      value = var.flower_basic_auth_password
-    }
-  }
-
-  dynamic "set_sensitive" {
-    for_each = local.flower_basic_auth_enabled ? ["flower-basic-auth-username"] : []
-    content {
-      name  = "flower.basicAuth.username"
-      value = var.flower_basic_auth_username
-    }
-  }
+  set_sensitive = concat(
+    [
+      { name = "auth.devToken.privateKey", value = var.dev_token_private_key },
+      { name = "redis.username", value = var.redis_username },
+      { name = "redis.password", value = var.redis_password },
+      { name = "db.username", value = var.db_username },
+      { name = "db.password", value = var.db_password },
+    ],
+    local.admin_enabled ? [
+      { name = "auth.admin.hashedPassword", value = bcrypt(var.admin_password) },
+    ] : [],
+    local.flower_basic_auth_enabled ? [
+      { name = "flower.basicAuth.password", value = var.flower_basic_auth_password },
+      { name = "flower.basicAuth.username", value = var.flower_basic_auth_username },
+    ] : [],
+  )
 
   lifecycle {
     precondition {

--- a/modules/cert-manager/main.tf
+++ b/modules/cert-manager/main.tf
@@ -5,10 +5,9 @@ resource "helm_release" "cert_manager" {
   namespace        = "cert-manager"
   create_namespace = true
 
-  set {
-    name  = "crds.enabled"
-    value = "true"
-  }
+  set = [
+    { name = "crds.enabled", value = "true" },
+  ]
 }
 
 resource "helm_release" "cluster_issuer" {
@@ -16,20 +15,11 @@ resource "helm_release" "cluster_issuer" {
   chart     = "${path.module}/charts/cluster-issuer"
   namespace = "cert-manager"
 
-  set {
-    name  = "email"
-    value = var.acme_email
-  }
-
-  set {
-    name  = "server"
-    value = var.acme_server
-  }
-
-  set {
-    name  = "privateKeySecretRef"
-    value = var.acme_private_key_secret
-  }
+  set = [
+    { name = "email", value = var.acme_email },
+    { name = "server", value = var.acme_server },
+    { name = "privateKeySecretRef", value = var.acme_private_key_secret },
+  ]
 
   depends_on = [helm_release.cert_manager]
 }

--- a/providers.tf
+++ b/providers.tf
@@ -12,7 +12,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
 }


### PR DESCRIPTION
## 📌 Summary

- Bump `hashicorp/helm` constraint from `~> 2.0` to `~> 3.0` (installed v3.1.1).
- Migrate provider config to v3 syntax: nested `kubernetes {}` block → attribute assignment (`kubernetes = {}`) in both examples.
- Migrate `helm_release` resources to v3 syntax: repeated `set {}` / `set_sensitive {}` blocks → list-of-object attributes (`set = [{...}]`, `set_sensitive = [{...}]`); reworked `dynamic` blocks in `modules/app` into `concat(...)` lists. Also updated `modules/cert-manager` (cert-manager + cluster-issuer releases).
- Validated locally with `terraform validate` in both `examples/basic` and `examples/oidc` (no cloud API calls / plan run).

Related PRs:
- aws: https://github.com/dbnlAI/terraform-aws-dbnl/pull/13
- google: https://github.com/dbnlAI/terraform-google-dbnl/pull/7